### PR TITLE
disable CGO explicitly

### DIFF
--- a/dockerfiles/go1.x/run/Dockerfile
+++ b/dockerfiles/go1.x/run/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY aws-lambda-mock.go ./
-RUN GOARCH=amd64 GOOS=linux go build aws-lambda-mock.go
+RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build aws-lambda-mock.go
 
 
 FROM public.ecr.aws/shogo82148/lambda-provided:alami

--- a/dockerfiles/provided.al2/run/Dockerfile
+++ b/dockerfiles/provided.al2/run/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY init.go ./
-RUN GOOS=linux go build -o init init.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o init init.go
 
 
 FROM public.ecr.aws/shogo82148/lambda-base:al2

--- a/dockerfiles/provided/run/Dockerfile
+++ b/dockerfiles/provided/run/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY init.go ./
-RUN GOOS=linux go build -o init init.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o init init.go
 
 
 FROM public.ecr.aws/shogo82148/lambda-base:alami

--- a/dump/go1.x/Makefile
+++ b/dump/go1.x/Makefile
@@ -7,7 +7,7 @@ dist.zip: dist/index
 
 dist/index: dump.go go.mod go.sum
 	mkdir -p dist
-	GOOS=linux GOARCH=amd64 go build -o dist/index dump.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o dist/index dump.go
 
 .PHONEY: deploy
 deploy: dist.zip

--- a/dump/layer/Makefile
+++ b/dump/layer/Makefile
@@ -7,7 +7,7 @@ dist/x86_64.zip: dist/x86_64/bin/lambda-dump
 
 dist/x86_64/bin/lambda-dump: main.go go.mod go.sum
 	mkdir -p dist/x86_64/bin
-	GOOS=linux GOARCH=amd64 go build -o $@ $<
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $@ $<
 
 dist/arm64.zip: dist/arm64/bin/lambda-dump
 	mkdir -p dist
@@ -15,7 +15,7 @@ dist/arm64.zip: dist/arm64/bin/lambda-dump
 
 dist/arm64/bin/lambda-dump: main.go go.mod go.sum
 	mkdir -p dist/arm64/bin
-	GOOS=linux GOARCH=arm64 go build -o $@ $<
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $@ $<
 
 .PHONEY: deploy
 deploy: dist/x86_64.zip dist/arm64.zip


### PR DESCRIPTION
Go binaries are statically linked in most cases, but not when CGO is included.
Since dynamically linked binaries may not work depending on the deployment environment, I will explicitly disable this