### PR TITLE
migrate set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       contents: read
     steps:
       - id: version
-        run: echo "::set-output name=result::$(date -u "+%Y.%m.%d")"
+        run: echo "result=$(date -u "+%Y.%m.%d")" >> "$GITHUB_OUTPUT"
     outputs:
       version: ${{ steps.version.outputs.result }}
 


### PR DESCRIPTION
`set-output` command is deprecated.
see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/