### PR TITLE
Update Dockerfile to use /var/rapid/init instead of /var/runtime/init

### DIFF
--- a/dockerfiles/java21/run/Dockerfile
+++ b/dockerfiles/java21/run/Dockerfile
@@ -22,7 +22,7 @@ ENV PATH=/var/lang/bin:$PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_java21
 
 COPY --from=0 /var /var
-COPY --from=0 /docker-lambda-init /var/runtime/init
+COPY --from=0 /docker-lambda-init /var/rapid/init
 
 USER sbx_user1051
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated file copying destination in Docker configuration for improved file management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->