### PR TITLE
Add Python 3.12 to the dump matrix

### DIFF
--- a/.github/workflows/dump.yml
+++ b/.github/workflows/dump.yml
@@ -38,6 +38,7 @@ jobs:
           - python3.9
           - python3.10
           - python3.11
+          - python3.12
           - ruby2.7
           - ruby3.2
           - ruby3.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow to support Python 3.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->