### PR TITLE
fix the base image of the Python 3.12 runtime

### DIFF
--- a/dockerfiles/python3.12/build/Dockerfile
+++ b/dockerfiles/python3.12/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=$BUILDPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-RUN dnf install -y curl tar gzip
+RUN dnf install -y tar gzip
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/dockerfiles/python3.12/build/Dockerfile
+++ b/dockerfiles/python3.12/build/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=$BUILDPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM --platform=$BUILDPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-RUN yum install -y curl tar gzip
+RUN dnf install -y curl tar gzip
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -11,10 +11,10 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.02.09
+FROM public.ecr.aws/shogo82148/lambda-base:build-al2023.2024.04.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
-    AWS_EXECUTION_ENV=AWS_Lambda_python3.11
+    AWS_EXECUTION_ENV=AWS_Lambda_python3.12
 
 COPY --from=0 /var /var

--- a/dockerfiles/python3.12/run/Dockerfile
+++ b/dockerfiles/python3.12/run/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=$BUILDPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM --platform=$BUILDPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-RUN yum install -y tar gzip
+RUN dnf install -y tar gzip
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -15,11 +15,11 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.02.09
+FROM public.ecr.aws/shogo82148/lambda-base:al2023.2024.04.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
-    AWS_EXECUTION_ENV=AWS_Lambda_python3.11
+    AWS_EXECUTION_ENV=AWS_Lambda_python3.12
 
 COPY --from=0 /var /var
 COPY --from=0 /docker-lambda-init /var/rapid/init


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the base operating system to `amazonlinux:2023` for enhanced security and performance.
	- Transitioned from `yum` to `dnf` for package management to improve installation efficiency.
	- Updated environment configurations to support Python 3.12 in AWS Lambda.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->