### PR TITLE
fix typo: s/PHONEY/PHONY/

### DIFF
--- a/dump/base.al2/Makefile
+++ b/dump/base.al2/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.js
@@ -9,21 +9,21 @@ dist/index.js: index.js
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist

--- a/dump/base.al2023/Makefile
+++ b/dump/base.al2023/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist_x86_64.zip dist_arm64.zip
 
 dist_x86_64.zip: dist_x86_64/bootstrap
@@ -17,23 +17,23 @@ dist_arm64/bootstrap: dump.go go.mod go.sum
 	mkdir -p dist_arm64
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o dist_arm64/bootstrap dump.go
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist_x86_64.zip dist_arm64.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 	go test ./...
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/base/Makefile
+++ b/dump/base/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/bootstrap
@@ -9,21 +9,21 @@ dist/bootstrap: bootstrap
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n bootstrap
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/dotnet6/Makefile
+++ b/dump/dotnet6/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/dump_dotnet6.dll
@@ -8,23 +8,23 @@ dist.zip: dist/dump_dotnet6.dll
 dist/dump_dotnet6.dll: Function.cs dump-dotnet6.csproj
 	./build.sh
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 	./build.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/dotnet8/Makefile
+++ b/dump/dotnet8/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/dump_dotnet8.dll
@@ -8,23 +8,23 @@ dist.zip: dist/dump_dotnet8.dll
 dist/dump_dotnet8.dll: Function.cs dump-dotnet8.csproj
 	./build.sh
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 	./build.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/dotnetcore3.1/Makefile
+++ b/dump/dotnetcore3.1/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/dump_dotnetcore31.dll
@@ -8,23 +8,23 @@ dist.zip: dist/dump_dotnetcore31.dll
 dist/dump_dotnetcore31.dll: Function.cs dump-dotnetcore31.csproj
 	./build.sh
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 	./build.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/go1.x/Makefile
+++ b/dump/go1.x/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index
@@ -9,21 +9,21 @@ dist/index: dump.go go.mod go.sum
 	mkdir -p dist
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o dist/index dump.go
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 	go test ./...
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/java11/Makefile
+++ b/dump/java11/Makefile
@@ -1,26 +1,26 @@
-.PHONEY: all
+.PHONY: all
 all: build/distributions/app.zip
 
 build/distributions/app.zip: src/main/java/com/shogo82148/lambda/DumpJava11.java build.gradle build.sh
 	./build.sh
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: build/distributions/app.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 	./build.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -f build
 	-rm -f out.json

--- a/dump/java17/Makefile
+++ b/dump/java17/Makefile
@@ -1,26 +1,26 @@
-.PHONEY: all
+.PHONY: all
 all: build/distributions/app.zip
 
 build/distributions/app.zip: src/main/java/com/shogo82148/lambda/DumpJava17.java build.gradle build.sh
 	./build.sh
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: build/distributions/app.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 	./build.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -f build
 	-rm -f out.json

--- a/dump/java21/Makefile
+++ b/dump/java21/Makefile
@@ -1,26 +1,26 @@
-.PHONEY: all
+.PHONY: all
 all: build/distributions/app.zip
 
 build/distributions/app.zip: src/main/java/com/shogo82148/lambda/DumpJava21.java build.gradle build.sh
 	./build.sh
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: build/distributions/app.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 	./build.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -f build
 	-rm -f out.json

--- a/dump/java8.al2/Makefile
+++ b/dump/java8.al2/Makefile
@@ -1,26 +1,26 @@
-.PHONEY: all
+.PHONY: all
 all: build/distributions/app.zip
 
 build/distributions/app.zip: src/main/java/com/shogo82148/lambda/DumpJava8.java build.gradle build.sh
 	./build.sh
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: build/distributions/app.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 	./build.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -f build
 	-rm -f out.json

--- a/dump/java8/Makefile
+++ b/dump/java8/Makefile
@@ -1,24 +1,24 @@
-.PHONEY: all
+.PHONY: all
 all: build/distributions/app.zip
 
 build/distributions/app.zip: src/main/java/com/shogo82148/lambda/DumpJava8.java build.gradle build.sh
 	./build.sh
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: build/distributions/app.zip
 	./deploy.sh x86_64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 	./build.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -f build
 	-rm -f out.json

--- a/dump/layer/Makefile
+++ b/dump/layer/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist/x86_64.zip dist/arm64.zip
 
 dist/x86_64.zip: dist/x86_64/bin/lambda-dump
@@ -17,16 +17,16 @@ dist/arm64/bin/lambda-dump: main.go go.mod go.sum
 	mkdir -p dist/arm64/bin
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $@ $<
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist/x86_64.zip dist/arm64.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	go test ./...
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist

--- a/dump/nodejs12.x/Makefile
+++ b/dump/nodejs12.x/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.js
@@ -9,21 +9,21 @@ dist/index.js: index.js
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist

--- a/dump/nodejs14.x/Makefile
+++ b/dump/nodejs14.x/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.js
@@ -9,21 +9,21 @@ dist/index.js: index.js
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist

--- a/dump/nodejs16.x/Makefile
+++ b/dump/nodejs16.x/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.js
@@ -9,21 +9,21 @@ dist/index.js: index.js
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist

--- a/dump/nodejs18.x/Makefile
+++ b/dump/nodejs18.x/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.js
@@ -9,21 +9,21 @@ dist/index.js: index.js
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist

--- a/dump/nodejs20.x/Makefile
+++ b/dump/nodejs20.x/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.js
@@ -9,21 +9,21 @@ dist/index.js: index.js
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist

--- a/dump/nodejs22.x/Makefile
+++ b/dump/nodejs22.x/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.js
@@ -9,21 +9,21 @@ dist/index.js: index.js
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist

--- a/dump/provided.al2/Makefile
+++ b/dump/provided.al2/Makefile
@@ -1,14 +1,14 @@
-.PHONEY: all
+.PHONY: all
 all:
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy:
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 
-.PHONEY: test
+.PHONY: test
 test:
 
-.PHONEY: clean
+.PHONY: clean
 clean:

--- a/dump/provided.al2023/Makefile
+++ b/dump/provided.al2023/Makefile
@@ -1,14 +1,14 @@
-.PHONEY: all
+.PHONY: all
 all:
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy:
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 
-.PHONEY: test
+.PHONY: test
 test:
 
-.PHONEY: clean
+.PHONY: clean
 clean:

--- a/dump/provided/Makefile
+++ b/dump/provided/Makefile
@@ -1,14 +1,14 @@
-.PHONEY: all
+.PHONY: all
 all:
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy:
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 
-.PHONEY: test
+.PHONY: test
 test:
 
-.PHONEY: clean
+.PHONY: clean
 clean:

--- a/dump/python3.10/Makefile
+++ b/dump/python3.10/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.py
@@ -9,22 +9,22 @@ dist/index.py: index.py
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/python3.11/Makefile
+++ b/dump/python3.11/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.py
@@ -9,22 +9,22 @@ dist/index.py: index.py
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/python3.12/Makefile
+++ b/dump/python3.12/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.py
@@ -9,22 +9,22 @@ dist/index.py: index.py
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/python3.6/Makefile
+++ b/dump/python3.6/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.py
@@ -9,20 +9,20 @@ dist/index.py: index.py
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/python3.7/Makefile
+++ b/dump/python3.7/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.py
@@ -9,20 +9,20 @@ dist/index.py: index.py
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/python3.8/Makefile
+++ b/dump/python3.8/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.py
@@ -9,27 +9,27 @@ dist/index.py: index.py
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/python3.9/Makefile
+++ b/dump/python3.9/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.py
@@ -9,22 +9,22 @@ dist/index.py: index.py
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/ruby2.7/Makefile
+++ b/dump/ruby2.7/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.rb
@@ -9,22 +9,22 @@ dist/index.rb: index.rb
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip

--- a/dump/ruby3.2/Makefile
+++ b/dump/ruby3.2/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all
+.PHONY: all
 all: dist.zip
 
 dist.zip: dist/index.rb
@@ -9,22 +9,22 @@ dist/index.rb: index.rb
 	mkdir -p dist
 	cp $< $@
 
-.PHONEY: deploy
+.PHONY: deploy
 deploy: dist.zip
 	./deploy.sh x86_64
 	./deploy.sh arm64
 
-.PHONEY: dump
+.PHONY: dump
 dump:
 	./dump.sh x86_64
 	./dump.sh arm64
 
-.PHONEY: test
+.PHONY: test
 test:
 	bash -n deploy.sh
 	bash -n dump.sh
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	-rm -rf dist
 	-rm -f dist.zip


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated phony target declarations from `.PHONEY` to `.PHONY` across multiple Makefiles, ensuring correct syntax without changing functionality. Targets affected include `all`, `deploy`, `dump`, `test`, and `clean`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->