### PR TITLE
use ghcr.io instead of public.ecr.aws

### DIFF
--- a/.github/workflows/base.al2-build.yml
+++ b/.github/workflows/base.al2-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/base.al2/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/base.al2/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/base.al2-run.yml
+++ b/.github/workflows/base.al2-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/base.al2/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/base.al2/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/base.al2023-build.yml
+++ b/.github/workflows/base.al2023-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/base.al2023/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/base.al2023/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/base.al2023-run.yml
+++ b/.github/workflows/base.al2023-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/base.al2023/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/base.al2023/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/dotnet6-build.yml
+++ b/.github/workflows/dotnet6-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/dotnet6/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/dotnet6/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/dotnet6-run.yml
+++ b/.github/workflows/dotnet6-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/dotnet6/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/dotnet6/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/dotnet8-build.yml
+++ b/.github/workflows/dotnet8-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/dotnet8/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/dotnet8/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/dotnet8-run.yml
+++ b/.github/workflows/dotnet8-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/dotnet8/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/dotnet8/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/java11-build.yml
+++ b/.github/workflows/java11-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/java11/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/java11/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/java11-run.yml
+++ b/.github/workflows/java11-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/java11/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/java11/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/java17-build.yml
+++ b/.github/workflows/java17-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/java17/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/java17/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/java17-run.yml
+++ b/.github/workflows/java17-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/java17/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/java17/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/java21-build.yml
+++ b/.github/workflows/java21-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/java21/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/java21/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/java21-run.yml
+++ b/.github/workflows/java21-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/java21/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/java21/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/java8.al2-build.yml
+++ b/.github/workflows/java8.al2-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/java8.al2/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/java8.al2/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/java8.al2-run.yml
+++ b/.github/workflows/java8.al2-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/java8.al2/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/java8.al2/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/nodejs18.x-build.yml
+++ b/.github/workflows/nodejs18.x-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/nodejs18.x/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/nodejs18.x/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/nodejs18.x-run.yml
+++ b/.github/workflows/nodejs18.x-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/nodejs18.x/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/nodejs18.x/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/nodejs20.x-build.yml
+++ b/.github/workflows/nodejs20.x-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/nodejs20.x/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/nodejs20.x/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/nodejs20.x-run.yml
+++ b/.github/workflows/nodejs20.x-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/nodejs20.x/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/nodejs20.x/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/nodejs22.x-build.yml
+++ b/.github/workflows/nodejs22.x-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/nodejs22.x/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/nodejs22.x/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/nodejs22.x-run.yml
+++ b/.github/workflows/nodejs22.x-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/nodejs22.x/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/nodejs22.x/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/provided.al2-build.yml
+++ b/.github/workflows/provided.al2-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/provided.al2/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/provided.al2/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/provided.al2-run.yml
+++ b/.github/workflows/provided.al2-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/provided.al2/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/provided.al2/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/provided.al2023-build.yml
+++ b/.github/workflows/provided.al2023-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/provided.al2023/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/provided.al2023/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/provided.al2023-run.yml
+++ b/.github/workflows/provided.al2023-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/provided.al2023/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/provided.al2023/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/python3.10-build.yml
+++ b/.github/workflows/python3.10-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/python3.10/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/python3.10/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/python3.10-run.yml
+++ b/.github/workflows/python3.10-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/python3.10/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/python3.10/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/python3.11-build.yml
+++ b/.github/workflows/python3.11-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/python3.11/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/python3.11/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/python3.11-run.yml
+++ b/.github/workflows/python3.11-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/python3.11/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/python3.11/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/python3.12-build.yml
+++ b/.github/workflows/python3.12-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/python3.12/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/python3.12/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/python3.12-run.yml
+++ b/.github/workflows/python3.12-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/python3.12/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/python3.12/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/python3.13-build.yml
+++ b/.github/workflows/python3.13-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/python3.13/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/python3.13/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/python3.13-run.yml
+++ b/.github/workflows/python3.13-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/python3.13/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/python3.13/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/python3.8-build.yml
+++ b/.github/workflows/python3.8-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/python3.8/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/python3.8/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/python3.8-run.yml
+++ b/.github/workflows/python3.8-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/python3.8/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/python3.8/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/python3.9-build.yml
+++ b/.github/workflows/python3.9-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/python3.9/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/python3.9/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/python3.9-run.yml
+++ b/.github/workflows/python3.9-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/python3.9/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/python3.9/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/ruby3.2-build.yml
+++ b/.github/workflows/ruby3.2-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/ruby3.2/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/ruby3.2/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/ruby3.2-run.yml
+++ b/.github/workflows/ruby3.2-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/ruby3.2/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/ruby3.2/publish-run.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/ruby3.3-build.yml
+++ b/.github/workflows/ruby3.3-build.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/ruby3.3/publish-build.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/ruby3.3/publish-build.sh "public.ecr.aws/shogo82148"

--- a/.github/workflows/ruby3.3-run.yml
+++ b/.github/workflows/ruby3.3-run.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/ruby3.3/publish-run.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/ruby3.3/publish-run.sh "public.ecr.aws/shogo82148"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ handler and the second for the event, ie:
 docker run --rm \
   -v <code_dir>:/var/task:ro,delegated \
   [-v <layer_dir>:/opt:ro,delegated] \
-  public.ecr.aws/shogo82148/lambda-<runtime>:<runtime-version> \
+  ghcr.io/shogo82148/lambda-<runtime>:<runtime-version> \
   [<handler>] [<event>]
 ```
 
@@ -56,6 +56,10 @@ and the `ro,delegated` options ensure the directories are mounted read-only and 
 
 You can pass environment variables (eg `-e AWS_ACCESS_KEY_ID=abcd`) to talk to live AWS services,
 or modify aspects of the runtime. See [below](#environment-variables) for a list.
+
+> [!WARNING]
+> public.ecr.aws/shogo82148 has been deprecated.
+> It will no longer receive updates.
 
 #### Running in "stay-open" API mode
 
@@ -70,7 +74,7 @@ docker run --rm [-d] \
   -p 9001:9001 \
   -v <code_dir>:/var/task:ro,delegated \
   [-v <layer_dir>:/opt:ro,delegated] \
-  public.ecr.aws/shogo82148/lambda-<runtime>:<runtime-version> \
+  ghcr.io/shogo82148/lambda-<runtime>:<runtime-version> \
   [<handler>]
 ```
 
@@ -118,7 +122,7 @@ To enable this, pass `-e DOCKER_LAMBDA_WATCH=1` to `docker run`:
 docker run --rm \
   -e DOCKER_LAMBDA_WATCH=1 -e DOCKER_LAMBDA_STAY_OPEN=1 -p 9001:9001 \
   -v "$PWD":/var/task:ro,delegated \
-  public.ecr.aws/shogo82148/lambda-java:11 handler
+  ghcr.io/shogo82148/lambda-java:11 handler
 ```
 
 Then when you make changes to any file in the mounted directory, you'll see:
@@ -141,7 +145,7 @@ need to run watch mode like this instead:
 docker run --restart on-failure \
   -e DOCKER_LAMBDA_WATCH=1 -e DOCKER_LAMBDA_STAY_OPEN=1 -p 9001:9001 \
   -v "$PWD":/var/task:ro,delegated \
-  public.ecr.aws/shogo82148/lambda-java:11 handler
+  ghcr.io/shogo82148/lambda-java:11 handler
 ```
 
 When you make changes to any file in the mounted directory, you'll see:
@@ -160,7 +164,7 @@ If none of the above strategies work for you, you can use a file-watching utilit
 nodemon -w ./ -e '' -s SIGINT -x docker -- run --rm \
   -e DOCKER_LAMBDA_STAY_OPEN=1 -p 9001:9001 \
   -v "$PWD":/var/task:ro,delegated \
-  public.ecr.aws/shogo82148/lambda-provided:al2 handler
+  ghcr.io/shogo82148/lambda-provided:al2 handler
 ```
 
 ### Building Lambda functions
@@ -171,53 +175,53 @@ intended for building and packaging your Lambda functions. You can run your buil
 all from within the image.
 
 ```sh
-docker run [--rm] -v <code_dir>:/var/task [-v <layer_dir>:/opt] public.ecr.aws/shogo82148/lambda-<runtime>:build-<runtime-version> <build-cmd>
+docker run [--rm] -v <code_dir>:/var/task [-v <layer_dir>:/opt] ghcr.io/shogo82148/lambda-<runtime>:build-<runtime-version> <build-cmd>
 ```
 
 ## Migrate from lambci/docker-lambda
 
-Replace `lambci/lambda:<runtime><runtime-version>` into `public.ecr.aws/shogo82148/lambda-<runtime>:<runtime-version>`, and `lambci/lambda:build-<runtime><runtime-version>` into `public.ecr.aws/shogo82148/lambda-<runtime>:build-<runtime-version>`.
+Replace `lambci/lambda:<runtime><runtime-version>` into `ghcr.io/shogo82148/lambda-<runtime>:<runtime-version>`, and `lambci/lambda:build-<runtime><runtime-version>` into `ghcr.io/shogo82148/lambda-<runtime>:build-<runtime-version>`.
 See [Docker tags](#docker-tags) for available tags.
 
 ## Run Examples
 
 ```sh
 # Test a `handler` function from an `index.js` file in the current directory on Node.js v18.x
-docker run --rm -v "$PWD":/var/task:ro,delegated public.ecr.aws/shogo82148/lambda-nodejs:18 index.handler
+docker run --rm -v "$PWD":/var/task:ro,delegated ghcr.io/shogo82148/lambda-nodejs:18 index.handler
 
 # Using a different file and handler, with a custom event
-docker run --rm -v "$PWD":/var/task:ro,delegated public.ecr.aws/shogo82148/lambda-nodejs:18 app.myHandler '{"some": "event"}'
+docker run --rm -v "$PWD":/var/task:ro,delegated ghcr.io/shogo82148/lambda-nodejs:18 app.myHandler '{"some": "event"}'
 
 # Test a `lambda_handler` function in `lambda_function.py` with an empty event on Python 3.10
-docker run --rm -v "$PWD":/var/task:ro,delegated public.ecr.aws/shogo82148/lambda-python:3.10 lambda_function.lambda_handler
+docker run --rm -v "$PWD":/var/task:ro,delegated ghcr.io/shogo82148/lambda-python:3.10 lambda_function.lambda_handler
 
 # Similarly with Ruby 2.7
-docker run --rm -v "$PWD":/var/task:ro,delegated public.ecr.aws/shogo82148/lambda-ruby:2.7 lambda_function.lambda_handler
+docker run --rm -v "$PWD":/var/task:ro,delegated ghcr.io/shogo82148/lambda-ruby:2.7 lambda_function.lambda_handler
 
 # Test on provided.al2 with a compiled handler named my_handler and a custom event
-docker run --rm -v "$PWD":/var/task:ro,delegated public.ecr.aws/shogo82148/lambda-provided:al2 my_handler '{"some": "event"}'
+docker run --rm -v "$PWD":/var/task:ro,delegated ghcr.io/shogo82148/lambda-provided:al2 my_handler '{"some": "event"}'
 
 # Test a function from the current directory on Java 17
 # The directory must be laid out in the same way the Lambda zip file is,
 # with top-level package source directories and a `lib` directory for third-party jars
 # https://docs.aws.amazon.com/lambda/latest/dg/java-package.html
-docker run --rm -v "$PWD":/var/task:ro,delegated public.ecr.aws/shogo82148/lambda-java:17 org.myorg.MyHandler
+docker run --rm -v "$PWD":/var/task:ro,delegated ghcr.io/shogo82148/lambda-java:17 org.myorg.MyHandler
 
 # Test on .NET 6 given a test.dll assembly in the current directory,
 # a class named Function with a FunctionHandler method, and a custom event
-docker run --rm -v "$PWD":/var/task:ro,delegated public.ecr.aws/shogo82148/lambda-dotnet:6 test::test.Function::FunctionHandler '{"some": "event"}'
+docker run --rm -v "$PWD":/var/task:ro,delegated ghcr.io/shogo82148/lambda-dotnet:6 test::test.Function::FunctionHandler '{"some": "event"}'
 
 # Test with a provided.al2 runtime (assumes you have a `bootstrap` executable in the current directory)
-docker run --rm -v "$PWD":/var/task:ro,delegated public.ecr.aws/shogo82148/lambda-provided:al2 handler '{"some": "event"}'
+docker run --rm -v "$PWD":/var/task:ro,delegated ghcr.io/shogo82148/lambda-provided:al2 handler '{"some": "event"}'
 
 # Test with layers (assumes your function code is in `./fn` and your layers in `./layer`)
-docker run --rm -v "$PWD"/fn:/var/task:ro,delegated -v "$PWD"/layer:/opt:ro,delegated public.ecr.aws/shogo82148/lambda-nodejs:18
+docker run --rm -v "$PWD"/fn:/var/task:ro,delegated -v "$PWD"/layer:/opt:ro,delegated ghcr.io/shogo82148/lambda-nodejs:18
 
 # Run custom commands
-docker run --rm --entrypoint node public.ecr.aws/shogo82148/lambda-nodejs:18 -v
+docker run --rm --entrypoint node ghcr.io/shogo82148/lambda-nodejs:18 -v
 
 # For large events you can pipe them into stdin if you set DOCKER_LAMBDA_USE_STDIN
-echo '{"some": "event"}' | docker run --rm -v "$PWD":/var/task:ro,delegated -i -e DOCKER_LAMBDA_USE_STDIN=1 public.ecr.aws/shogo82148/lambda-nodejs:18
+echo '{"some": "event"}' | docker run --rm -v "$PWD":/var/task:ro,delegated -i -e DOCKER_LAMBDA_USE_STDIN=1 ghcr.io/shogo82148/lambda-nodejs:18
 ```
 
 You can see more examples of how to build docker images and run different
@@ -229,23 +233,23 @@ To use the build images, for compilation, deployment, etc:
 
 ```sh
 # To compile native deps in node_modules
-docker run --rm -v "$PWD":/var/task public.ecr.aws/shogo82148/lambda-nodejs:build-18 npm rebuild --build-from-source
+docker run --rm -v "$PWD":/var/task ghcr.io/shogo82148/lambda-nodejs:build-18 npm rebuild --build-from-source
 
 # To install defined poetry dependencies
-docker run --rm -v "$PWD":/var/task public.ecr.aws/shogo82148/lambda-python:build-3.10 poetry install
+docker run --rm -v "$PWD":/var/task ghcr.io/shogo82148/lambda-python:build-3.10 poetry install
 
 # To resolve dependencies on provided.al2 (working directory is /go/src/handler)
-docker run --rm -v "$PWD":/go/src/handler public.ecr.aws/shogo82148/lambda-provided:build-al2 go mod download
+docker run --rm -v "$PWD":/go/src/handler ghcr.io/shogo82148/lambda-provided:build-al2 go mod download
 
 # For .NET, this will publish the compiled code to `./pub`,
 # which you can then use to run with `-v "$PWD"/pub:/var/task`
-docker run --rm -v "$PWD":/var/task public.ecr.aws/shogo82148/lambda-dotnet:build-6 dotnet publish -c Release -o pub
+docker run --rm -v "$PWD":/var/task ghcr.io/shogo82148/lambda-dotnet:build-6 dotnet publish -c Release -o pub
 
 # Run custom commands on a build container
-docker run --rm public.ecr.aws/shogo82148/lambda-python:build-3.10 aws --version
+docker run --rm ghcr.io/shogo82148/lambda-python:build-3.10 aws --version
 
 # To run an interactive session on a build container
-docker run -it public.ecr.aws/shogo82148/lambda-python:build-3.10 bash
+docker run -it ghcr.io/shogo82148/lambda-python:build-3.10 bash
 ```
 
 ## Using a Dockerfile to build
@@ -253,7 +257,7 @@ docker run -it public.ecr.aws/shogo82148/lambda-python:build-3.10 bash
 Create your own Docker image to build and deploy:
 
 ```dockerfile
-FROM public.ecr.aws/shogo82148/lambda-nodejs:build-14
+FROM ghcr.io/shogo82148/lambda-nodejs:build-14
 
 ENV AWS_DEFAULT_REGION us-east-1
 
@@ -279,130 +283,130 @@ These follow the Lambda runtime names:
 
 - [Node.js Runtimes](https://gallery.ecr.aws/shogo82148/lambda-nodejs)
 
-  - `public.ecr.aws/shogo82148/lambda-nodejs:22`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:22-arm64`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:22-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:build-22`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:build-22-arm64`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:build-22-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:20`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:20-arm64`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:20-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:build-20`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:build-20-arm64`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:build-20-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:18`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:18-arm64`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:18-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:build-18`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:build-18-arm64`
-  - `public.ecr.aws/shogo82148/lambda-nodejs:build-18-x86_64`
+  - `ghcr.io/shogo82148/lambda-nodejs:22`
+  - `ghcr.io/shogo82148/lambda-nodejs:22-arm64`
+  - `ghcr.io/shogo82148/lambda-nodejs:22-x86_64`
+  - `ghcr.io/shogo82148/lambda-nodejs:build-22`
+  - `ghcr.io/shogo82148/lambda-nodejs:build-22-arm64`
+  - `ghcr.io/shogo82148/lambda-nodejs:build-22-x86_64`
+  - `ghcr.io/shogo82148/lambda-nodejs:20`
+  - `ghcr.io/shogo82148/lambda-nodejs:20-arm64`
+  - `ghcr.io/shogo82148/lambda-nodejs:20-x86_64`
+  - `ghcr.io/shogo82148/lambda-nodejs:build-20`
+  - `ghcr.io/shogo82148/lambda-nodejs:build-20-arm64`
+  - `ghcr.io/shogo82148/lambda-nodejs:build-20-x86_64`
+  - `ghcr.io/shogo82148/lambda-nodejs:18`
+  - `ghcr.io/shogo82148/lambda-nodejs:18-arm64`
+  - `ghcr.io/shogo82148/lambda-nodejs:18-x86_64`
+  - `ghcr.io/shogo82148/lambda-nodejs:build-18`
+  - `ghcr.io/shogo82148/lambda-nodejs:build-18-arm64`
+  - `ghcr.io/shogo82148/lambda-nodejs:build-18-x86_64`
 
 - [Python Runtimes](https://gallery.ecr.aws/shogo82148/lambda-python)
 
-  - `public.ecr.aws/shogo82148/lambda-python:3.13`
-  - `public.ecr.aws/shogo82148/lambda-python:3.13-arm64`
-  - `public.ecr.aws/shogo82148/lambda-python:3.13-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.13`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.13-arm64`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.13-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-python:3.12`
-  - `public.ecr.aws/shogo82148/lambda-python:3.12-arm64`
-  - `public.ecr.aws/shogo82148/lambda-python:3.12-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.12`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.12-arm64`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.12-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-python:3.11`
-  - `public.ecr.aws/shogo82148/lambda-python:3.11-arm64`
-  - `public.ecr.aws/shogo82148/lambda-python:3.11-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.11`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.11-arm64`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.11-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-python:3.10`
-  - `public.ecr.aws/shogo82148/lambda-python:3.10-arm64`
-  - `public.ecr.aws/shogo82148/lambda-python:3.10-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.10`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.10-arm64`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.10-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-python:3.9`
-  - `public.ecr.aws/shogo82148/lambda-python:3.9-arm64`
-  - `public.ecr.aws/shogo82148/lambda-python:3.9-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.9`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.9-arm64`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.9-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-python:3.8`
-  - `public.ecr.aws/shogo82148/lambda-python:3.8-arm64`
-  - `public.ecr.aws/shogo82148/lambda-python:3.8-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.8`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.8-arm64`
-  - `public.ecr.aws/shogo82148/lambda-python:build-3.8-x86_64`
+  - `ghcr.io/shogo82148/lambda-python:3.13`
+  - `ghcr.io/shogo82148/lambda-python:3.13-arm64`
+  - `ghcr.io/shogo82148/lambda-python:3.13-x86_64`
+  - `ghcr.io/shogo82148/lambda-python:build-3.13`
+  - `ghcr.io/shogo82148/lambda-python:build-3.13-arm64`
+  - `ghcr.io/shogo82148/lambda-python:build-3.13-x86_64`
+  - `ghcr.io/shogo82148/lambda-python:3.12`
+  - `ghcr.io/shogo82148/lambda-python:3.12-arm64`
+  - `ghcr.io/shogo82148/lambda-python:3.12-x86_64`
+  - `ghcr.io/shogo82148/lambda-python:build-3.12`
+  - `ghcr.io/shogo82148/lambda-python:build-3.12-arm64`
+  - `ghcr.io/shogo82148/lambda-python:build-3.12-x86_64`
+  - `ghcr.io/shogo82148/lambda-python:3.11`
+  - `ghcr.io/shogo82148/lambda-python:3.11-arm64`
+  - `ghcr.io/shogo82148/lambda-python:3.11-x86_64`
+  - `ghcr.io/shogo82148/lambda-python:build-3.11`
+  - `ghcr.io/shogo82148/lambda-python:build-3.11-arm64`
+  - `ghcr.io/shogo82148/lambda-python:build-3.11-x86_64`
+  - `ghcr.io/shogo82148/lambda-python:3.10`
+  - `ghcr.io/shogo82148/lambda-python:3.10-arm64`
+  - `ghcr.io/shogo82148/lambda-python:3.10-x86_64`
+  - `ghcr.io/shogo82148/lambda-python:build-3.10`
+  - `ghcr.io/shogo82148/lambda-python:build-3.10-arm64`
+  - `ghcr.io/shogo82148/lambda-python:build-3.10-x86_64`
+  - `ghcr.io/shogo82148/lambda-python:3.9`
+  - `ghcr.io/shogo82148/lambda-python:3.9-arm64`
+  - `ghcr.io/shogo82148/lambda-python:3.9-x86_64`
+  - `ghcr.io/shogo82148/lambda-python:build-3.9`
+  - `ghcr.io/shogo82148/lambda-python:build-3.9-arm64`
+  - `ghcr.io/shogo82148/lambda-python:build-3.9-x86_64`
+  - `ghcr.io/shogo82148/lambda-python:3.8`
+  - `ghcr.io/shogo82148/lambda-python:3.8-arm64`
+  - `ghcr.io/shogo82148/lambda-python:3.8-x86_64`
+  - `ghcr.io/shogo82148/lambda-python:build-3.8`
+  - `ghcr.io/shogo82148/lambda-python:build-3.8-arm64`
+  - `ghcr.io/shogo82148/lambda-python:build-3.8-x86_64`
 
 - [Ruby Runtimes](https://gallery.ecr.aws/shogo82148/lambda-ruby)
 
-  - `public.ecr.aws/shogo82148/lambda-ruby:3.3`
-  - `public.ecr.aws/shogo82148/lambda-ruby:3.3-arm64`
-  - `public.ecr.aws/shogo82148/lambda-ruby:3.3-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-ruby:build-3.3`
-  - `public.ecr.aws/shogo82148/lambda-ruby:build-3.3-arm64`
-  - `public.ecr.aws/shogo82148/lambda-ruby:build-3.3-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-ruby:3.2`
-  - `public.ecr.aws/shogo82148/lambda-ruby:3.2-arm64`
-  - `public.ecr.aws/shogo82148/lambda-ruby:3.2-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-ruby:build-3.2`
-  - `public.ecr.aws/shogo82148/lambda-ruby:build-3.2-arm64`
-  - `public.ecr.aws/shogo82148/lambda-ruby:build-3.2-x86_64`
+  - `ghcr.io/shogo82148/lambda-ruby:3.3`
+  - `ghcr.io/shogo82148/lambda-ruby:3.3-arm64`
+  - `ghcr.io/shogo82148/lambda-ruby:3.3-x86_64`
+  - `ghcr.io/shogo82148/lambda-ruby:build-3.3`
+  - `ghcr.io/shogo82148/lambda-ruby:build-3.3-arm64`
+  - `ghcr.io/shogo82148/lambda-ruby:build-3.3-x86_64`
+  - `ghcr.io/shogo82148/lambda-ruby:3.2`
+  - `ghcr.io/shogo82148/lambda-ruby:3.2-arm64`
+  - `ghcr.io/shogo82148/lambda-ruby:3.2-x86_64`
+  - `ghcr.io/shogo82148/lambda-ruby:build-3.2`
+  - `ghcr.io/shogo82148/lambda-ruby:build-3.2-arm64`
+  - `ghcr.io/shogo82148/lambda-ruby:build-3.2-x86_64`
 
 - [Java Runtimes](https://gallery.ecr.aws/shogo82148/lambda-java)
 
-  - `public.ecr.aws/shogo82148/lambda-java:21`
-  - `public.ecr.aws/shogo82148/lambda-java:21-arm64`
-  - `public.ecr.aws/shogo82148/lambda-java:21-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-java:build-21`
-  - `public.ecr.aws/shogo82148/lambda-java:build-21-arm64`
-  - `public.ecr.aws/shogo82148/lambda-java:build-21-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-java:17`
-  - `public.ecr.aws/shogo82148/lambda-java:17-arm64`
-  - `public.ecr.aws/shogo82148/lambda-java:17-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-java:build-17`
-  - `public.ecr.aws/shogo82148/lambda-java:build-17-arm64`
-  - `public.ecr.aws/shogo82148/lambda-java:build-17-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-java:11`
-  - `public.ecr.aws/shogo82148/lambda-java:11-arm64`
-  - `public.ecr.aws/shogo82148/lambda-java:11-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-java:build-11`
-  - `public.ecr.aws/shogo82148/lambda-java:build-11-arm64`
-  - `public.ecr.aws/shogo82148/lambda-java:build-11-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-java:8.al2`
-  - `public.ecr.aws/shogo82148/lambda-java:8.al2-arm64`
-  - `public.ecr.aws/shogo82148/lambda-java:8.al2-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-java:build-8.al2`
-  - `public.ecr.aws/shogo82148/lambda-java:build-8.al2-arm64`
-  - `public.ecr.aws/shogo82148/lambda-java:8.al2-x86_64`
+  - `ghcr.io/shogo82148/lambda-java:21`
+  - `ghcr.io/shogo82148/lambda-java:21-arm64`
+  - `ghcr.io/shogo82148/lambda-java:21-x86_64`
+  - `ghcr.io/shogo82148/lambda-java:build-21`
+  - `ghcr.io/shogo82148/lambda-java:build-21-arm64`
+  - `ghcr.io/shogo82148/lambda-java:build-21-x86_64`
+  - `ghcr.io/shogo82148/lambda-java:17`
+  - `ghcr.io/shogo82148/lambda-java:17-arm64`
+  - `ghcr.io/shogo82148/lambda-java:17-x86_64`
+  - `ghcr.io/shogo82148/lambda-java:build-17`
+  - `ghcr.io/shogo82148/lambda-java:build-17-arm64`
+  - `ghcr.io/shogo82148/lambda-java:build-17-x86_64`
+  - `ghcr.io/shogo82148/lambda-java:11`
+  - `ghcr.io/shogo82148/lambda-java:11-arm64`
+  - `ghcr.io/shogo82148/lambda-java:11-x86_64`
+  - `ghcr.io/shogo82148/lambda-java:build-11`
+  - `ghcr.io/shogo82148/lambda-java:build-11-arm64`
+  - `ghcr.io/shogo82148/lambda-java:build-11-x86_64`
+  - `ghcr.io/shogo82148/lambda-java:8.al2`
+  - `ghcr.io/shogo82148/lambda-java:8.al2-arm64`
+  - `ghcr.io/shogo82148/lambda-java:8.al2-x86_64`
+  - `ghcr.io/shogo82148/lambda-java:build-8.al2`
+  - `ghcr.io/shogo82148/lambda-java:build-8.al2-arm64`
+  - `ghcr.io/shogo82148/lambda-java:8.al2-x86_64`
 
 - [.Net Runtimes](https://gallery.ecr.aws/shogo82148/lambda-dotnet) and [.Net Core Runtimes](https://gallery.ecr.aws/shogo82148/lambda-dotnetcore)
 
-  - `public.ecr.aws/shogo82148/lambda-dotnet:6`
-  - `public.ecr.aws/shogo82148/lambda-dotnet:6-arm64`
-  - `public.ecr.aws/shogo82148/lambda-dotnet:6-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-dotnet:build-6`
-  - `public.ecr.aws/shogo82148/lambda-dotnet:build-6-arm64`
-  - `public.ecr.aws/shogo82148/lambda-dotnet:build-6-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-dotnetcore:3.1`
-  - `public.ecr.aws/shogo82148/lambda-dotnetcore:build-3.1`
+  - `ghcr.io/shogo82148/lambda-dotnet:6`
+  - `ghcr.io/shogo82148/lambda-dotnet:6-arm64`
+  - `ghcr.io/shogo82148/lambda-dotnet:6-x86_64`
+  - `ghcr.io/shogo82148/lambda-dotnet:build-6`
+  - `ghcr.io/shogo82148/lambda-dotnet:build-6-arm64`
+  - `ghcr.io/shogo82148/lambda-dotnet:build-6-x86_64`
+  - `ghcr.io/shogo82148/lambda-dotnetcore:3.1`
+  - `ghcr.io/shogo82148/lambda-dotnetcore:build-3.1`
 
 - [Provided Runtimes](https://gallery.ecr.aws/shogo82148/lambda-provided)
-  - `public.ecr.aws/shogo82148/lambda-provided:al2023`
-  - `public.ecr.aws/shogo82148/lambda-provided:al2023-arm64`
-  - `public.ecr.aws/shogo82148/lambda-provided:al2023-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-provided:build-al2023`
-  - `public.ecr.aws/shogo82148/lambda-provided:build-al2023-arm64`
-  - `public.ecr.aws/shogo82148/lambda-provided:build-al2023-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-provided:al2`
-  - `public.ecr.aws/shogo82148/lambda-provided:al2-arm64`
-  - `public.ecr.aws/shogo82148/lambda-provided:al2-x86_64`
-  - `public.ecr.aws/shogo82148/lambda-provided:build-al2`
-  - `public.ecr.aws/shogo82148/lambda-provided:build-al2-arm64`
-  - `public.ecr.aws/shogo82148/lambda-provided:build-al2-x86_64`
+  - `ghcr.io/shogo82148/lambda-provided:al2023`
+  - `ghcr.io/shogo82148/lambda-provided:al2023-arm64`
+  - `ghcr.io/shogo82148/lambda-provided:al2023-x86_64`
+  - `ghcr.io/shogo82148/lambda-provided:build-al2023`
+  - `ghcr.io/shogo82148/lambda-provided:build-al2023-arm64`
+  - `ghcr.io/shogo82148/lambda-provided:build-al2023-x86_64`
+  - `ghcr.io/shogo82148/lambda-provided:al2`
+  - `ghcr.io/shogo82148/lambda-provided:al2-arm64`
+  - `ghcr.io/shogo82148/lambda-provided:al2-x86_64`
+  - `ghcr.io/shogo82148/lambda-provided:build-al2`
+  - `ghcr.io/shogo82148/lambda-provided:build-al2-arm64`
+  - `ghcr.io/shogo82148/lambda-provided:build-al2-x86_64`
 
 ## Environment variables
 

--- a/dockerfiles/base.al2/build/Dockerfile
+++ b/dockerfiles/base.al2/build/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir /opt/etc && \
     --releasever="$(rpm --query --file --queryformat '%{VERSION}' /etc/system-release)" \
     install -y yum yum-plugin-ovl yum-plugin-priorities
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.12.13
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin \
   PIPX_BIN_DIR=/usr/local/bin \

--- a/dockerfiles/base.al2023/build/Dockerfile
+++ b/dockerfiles/base.al2023/build/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /opt/etc && \
   --releasever="$(rpm --query --file --queryformat '%{VERSION}' /etc/system-release)" \
   install -y dnf dnf-plugins-core
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:al2023.2024.11.26
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin \
   PIPX_BIN_DIR=/usr/local/bin \

--- a/dockerfiles/base/build/Dockerfile
+++ b/dockerfiles/base/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/shogo82148/lambda-base:alami.2024.08.09
+FROM ghcr.io/shogo82148/lambda-base:alami.2024.08.09
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin \
   PIPX_BIN_DIR=/usr/local/bin \

--- a/dockerfiles/base/run/Dockerfile
+++ b/dockerfiles/base/run/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM ghcr.io/amazonlinux/amazonlinux:2
 
 ENV ARCHIVE_URL_AMD64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/x86_64/base/4222b8c3cfa3d3a746bdb4c63678864bdb57c6382f8fb3f942ad4b279425d5b6.tgz
 

--- a/dockerfiles/dotnet6/build/Dockerfile
+++ b/dockerfiles/dotnet6/build/Dockerfile
@@ -11,9 +11,9 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.12.13
 
-# Run: docker run --rm --entrypoint dotnet public.ecr.aws/shogo82148/lambda-dotnetcore:6 --info
+# Run: docker run --rm --entrypoint dotnet ghcr.io/shogo82148/lambda-dotnetcore:6 --info
 # Check https://dotnet.microsoft.com/en-us/download/dotnet/6.0 for versions
 ENV DOTNET_ROOT=/var/lang/bin
 ENV PATH=/root/.dotnet/tools:$DOTNET_ROOT:$PATH \

--- a/dockerfiles/dotnet6/run/Dockerfile
+++ b/dockerfiles/dotnet6/run/Dockerfile
@@ -15,9 +15,9 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-provided:al2
+FROM ghcr.io/shogo82148/lambda-provided:al2
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/dotnet8/build/Dockerfile
+++ b/dockerfiles/dotnet8/build/Dockerfile
@@ -11,9 +11,9 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2023.2024.02.09
+FROM ghcr.io/shogo82148/lambda-base:build-al2023.2024.02.09
 
-# Run: docker run --rm --entrypoint dotnet public.ecr.aws/shogo82148/lambda-dotnetcore:8 --info
+# Run: docker run --rm --entrypoint dotnet ghcr.io/shogo82148/lambda-dotnetcore:8 --info
 # Check https://dotnet.microsoft.com/en-us/download/dotnet/8.0 for versions
 ENV DOTNET_ROOT=/var/lang/bin
 ENV PATH=/root/.dotnet/tools:$DOTNET_ROOT:$PATH \

--- a/dockerfiles/dotnet8/run/Dockerfile
+++ b/dockerfiles/dotnet8/run/Dockerfile
@@ -15,9 +15,9 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.0
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-provided:al2023
+FROM ghcr.io/shogo82148/lambda-provided:al2023
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2023.2024.02.09
+FROM ghcr.io/shogo82148/lambda-base:al2023.2024.02.09
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/dotnetcore3.1/build.sh
+++ b/dockerfiles/dotnetcore3.1/build.sh
@@ -2,5 +2,5 @@
 
 set -eux
 CURRENT=$(cd "$(dirname "$0")" && pwd)
-docker buildx build --platform linux/amd64,linux/arm64 -t public.ecr.aws/shogo82148/lambda-dotnetcore:3.1 "$CURRENT/run"
-docker buildx build --platform linux/amd64,linux/arm64 -t public.ecr.aws/shogo82148/lambda-dotnetcore:build-3.1 "$CURRENT/build"
+docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/shogo82148/lambda-dotnetcore:3.1 "$CURRENT/run"
+docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/shogo82148/lambda-dotnetcore:build-3.1 "$CURRENT/build"

--- a/dockerfiles/dotnetcore3.1/build/Dockerfile
+++ b/dockerfiles/dotnetcore3.1/build/Dockerfile
@@ -1,6 +1,6 @@
-﻿FROM public.ecr.aws/shogo82148/lambda-base:build-al2
+﻿FROM ghcr.io/shogo82148/lambda-base:build-al2
 
-# Run: docker run --rm --entrypoint dotnet public.ecr.aws/shogo82148/lambda-dotnetcore:3.1 --info
+# Run: docker run --rm --entrypoint dotnet ghcr.io/shogo82148/lambda-dotnetcore:3.1 --info
 # Check https://dotnet.microsoft.com/en-us/download/dotnet/3.1 for versions
 ENV DOTNET_ROOT=/var/lang/bin
 ENV PATH=/root/.dotnet/tools:$DOTNET_ROOT:$PATH \

--- a/dockerfiles/dotnetcore3.1/run/Dockerfile
+++ b/dockerfiles/dotnetcore3.1/run/Dockerfile
@@ -4,9 +4,9 @@ RUN yum install -y curl tar gzip
 RUN case $(uname -m) in "x86_64") ARCH=x86_64;; "aarch64") ARCH=arm64;; *) echo "unknown architecture: $(uname -m)"; exit 1;; esac && \
     curl -sSL "https://shogo82148-docker-lambda.s3.amazonaws.com/fs/$ARCH/dotnetcore3.1.tgz" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-provided:al2
+FROM ghcr.io/shogo82148/lambda-provided:al2
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2
+FROM ghcr.io/shogo82148/lambda-base:al2
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/go1.x/build/Dockerfile
+++ b/dockerfiles/go1.x/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/shogo82148/lambda-base:build-alami.2024.08.16
+FROM ghcr.io/shogo82148/lambda-base:build-alami.2024.08.16
 
 # https://golang.org/doc/devel/release.html
 ENV GOLANG_VERSION=1.22.1 \

--- a/dockerfiles/go1.x/run/Dockerfile
+++ b/dockerfiles/go1.x/run/Dockerfile
@@ -23,7 +23,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:alami.2024.08.09
+FROM ghcr.io/shogo82148/lambda-base:alami.2024.08.09
 
 ENV AWS_EXECUTION_ENV=AWS_Lambda_go1.x
 

--- a/dockerfiles/java11/build/Dockerfile
+++ b/dockerfiles/java11/build/Dockerfile
@@ -12,7 +12,7 @@ RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARC
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/java11/run/Dockerfile
+++ b/dockerfiles/java11/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/java17/build/Dockerfile
+++ b/dockerfiles/java17/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/java17/run/Dockerfile
+++ b/dockerfiles/java17/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/java21/build/Dockerfile
+++ b/dockerfiles/java21/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
     curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:build-al2023.2024.11.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/java21/run/Dockerfile
+++ b/dockerfiles/java21/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:al2023.2024.11.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/java8.al2/build/Dockerfile
+++ b/dockerfiles/java8.al2/build/Dockerfile
@@ -12,7 +12,7 @@ RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARC
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/java8.al2/run/Dockerfile
+++ b/dockerfiles/java8.al2/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/java8/build/Dockerfile
+++ b/dockerfiles/java8/build/Dockerfile
@@ -8,7 +8,7 @@ ENV ARCHIVE_URL_AMD64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/x86_6
 RUN curl -sSL "$ARCHIVE_URL_AMD64" | tar -zx -C /
 
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-alami.2024.08.16
+FROM ghcr.io/shogo82148/lambda-base:build-alami.2024.08.16
 
 ENV AWS_EXECUTION_ENV=AWS_Lambda_java8
 

--- a/dockerfiles/java8/run/Dockerfile
+++ b/dockerfiles/java8/run/Dockerfile
@@ -18,7 +18,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
 
-FROM public.ecr.aws/shogo82148/lambda-base:alami.2024.08.09
+FROM ghcr.io/shogo82148/lambda-base:alami.2024.08.09
 
 ENV AWS_EXECUTION_ENV=AWS_Lambda_java8
 

--- a/dockerfiles/nodejs12.x/build.sh
+++ b/dockerfiles/nodejs12.x/build.sh
@@ -2,5 +2,5 @@
 
 set -eux
 CURRENT=$(cd "$(dirname "$0")" && pwd)
-docker buildx build --platform linux/amd64,linux/arm64 -t public.ecr.aws/shogo82148/lambda-nodejs:12 "$CURRENT/run"
-docker buildx build --platform linux/amd64,linux/arm64 -t public.ecr.aws/shogo82148/lambda-nodejs:build-12 "$CURRENT/build"
+docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/shogo82148/lambda-nodejs:12 "$CURRENT/run"
+docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/shogo82148/lambda-nodejs:build-12 "$CURRENT/build"

--- a/dockerfiles/nodejs12.x/build/Dockerfile
+++ b/dockerfiles/nodejs12.x/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2
+FROM ghcr.io/shogo82148/lambda-base:build-al2
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/nodejs12.x/run/Dockerfile
+++ b/dockerfiles/nodejs12.x/run/Dockerfile
@@ -4,9 +4,9 @@ RUN yum install -y curl tar gzip
 RUN case $(uname -m) in "x86_64") ARCH=x86_64;; "aarch64") ARCH=arm64;; *) echo "unknown architecture: $(uname -m)"; exit 1;; esac && \
     curl -sSL "https://shogo82148-docker-lambda.s3.amazonaws.com/fs/$ARCH/nodejs12.x.tgz" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-provided:al2
+FROM ghcr.io/shogo82148/lambda-provided:al2
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2
+FROM ghcr.io/shogo82148/lambda-base:al2
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/nodejs14.x/build/Dockerfile
+++ b/dockerfiles/nodejs14.x/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.08.16
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.08.16
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/nodejs14.x/run/Dockerfile
+++ b/dockerfiles/nodejs14.x/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.08.09
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.08.09
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/nodejs16.x/build/Dockerfile
+++ b/dockerfiles/nodejs16.x/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.08.16
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.08.16
 
 
 ENV PATH=/var/lang/bin:$PATH \

--- a/dockerfiles/nodejs16.x/run/Dockerfile
+++ b/dockerfiles/nodejs16.x/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.08.09
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.08.09
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/nodejs18.x/build/Dockerfile
+++ b/dockerfiles/nodejs18.x/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/nodejs18.x/run/Dockerfile
+++ b/dockerfiles/nodejs18.x/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/nodejs20.x/build/Dockerfile
+++ b/dockerfiles/nodejs20.x/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
     curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:build-al2023.2024.11.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/nodejs20.x/run/Dockerfile
+++ b/dockerfiles/nodejs20.x/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:al2023.2024.11.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/nodejs22.x/build/Dockerfile
+++ b/dockerfiles/nodejs22.x/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
     curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2023.2024.11.15
+FROM ghcr.io/shogo82148/lambda-base:build-al2023.2024.11.15
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/nodejs22.x/run/Dockerfile
+++ b/dockerfiles/nodejs22.x/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2023.2024.11.15
+FROM ghcr.io/shogo82148/lambda-base:al2023.2024.11.15
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/provided.al2/build/Dockerfile
+++ b/dockerfiles/provided.al2/build/Dockerfile
@@ -9,6 +9,6 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.12.13
 
 COPY --from=0 /docker-lambda-init /var/runtime/init

--- a/dockerfiles/provided.al2/run/Dockerfile
+++ b/dockerfiles/provided.al2/run/Dockerfile
@@ -9,7 +9,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH

--- a/dockerfiles/provided.al2023/build/Dockerfile
+++ b/dockerfiles/provided.al2023/build/Dockerfile
@@ -9,6 +9,6 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:build-al2023.2024.11.26
 
 COPY --from=0 /docker-lambda-init /var/runtime/init

--- a/dockerfiles/provided.al2023/run/Dockerfile
+++ b/dockerfiles/provided.al2023/run/Dockerfile
@@ -9,7 +9,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:al2023.2024.11.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH

--- a/dockerfiles/provided/build/Dockerfile
+++ b/dockerfiles/provided/build/Dockerfile
@@ -8,6 +8,6 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-alami.2024.08.16
+FROM ghcr.io/shogo82148/lambda-base:build-alami.2024.08.16
 
 COPY --from=0 /docker-lambda-init /var/runtime/init

--- a/dockerfiles/provided/run/Dockerfile
+++ b/dockerfiles/provided/run/Dockerfile
@@ -7,7 +7,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:alami.2024.08.09
+FROM ghcr.io/shogo82148/lambda-base:alami.2024.08.09
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH

--- a/dockerfiles/python3.10/build/Dockerfile
+++ b/dockerfiles/python3.10/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.10/run/Dockerfile
+++ b/dockerfiles/python3.10/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.11/build/Dockerfile
+++ b/dockerfiles/python3.11/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.11/run/Dockerfile
+++ b/dockerfiles/python3.11/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.12/build/Dockerfile
+++ b/dockerfiles/python3.12/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:build-al2023.2024.11.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.12/run/Dockerfile
+++ b/dockerfiles/python3.12/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:al2023.2024.11.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.13/build/Dockerfile
+++ b/dockerfiles/python3.13/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:build-al2023.2024.11.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.13/run/Dockerfile
+++ b/dockerfiles/python3.13/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:al2023.2024.11.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.6/build.sh
+++ b/dockerfiles/python3.6/build.sh
@@ -2,5 +2,5 @@
 
 set -eux
 CURRENT=$(cd "$(dirname "$0")" && pwd)
-docker buildx build --platform linux/amd64 -t public.ecr.aws/shogo82148/lambda-python:3.6 "$CURRENT/run"
-docker buildx build --platform linux/amd64 -t public.ecr.aws/shogo82148/lambda-python:build-3.6 "$CURRENT/build"
+docker buildx build --platform linux/amd64 -t ghcr.io/shogo82148/lambda-python:3.6 "$CURRENT/run"
+docker buildx build --platform linux/amd64 -t ghcr.io/shogo82148/lambda-python:build-3.6 "$CURRENT/build"

--- a/dockerfiles/python3.6/build/Dockerfile
+++ b/dockerfiles/python3.6/build/Dockerfile
@@ -1,6 +1,6 @@
-FROM public.ecr.aws/shogo82148/lambda-python:3.6
+FROM ghcr.io/shogo82148/lambda-python:3.6
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2
+FROM ghcr.io/shogo82148/lambda-base:build-al2
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.6/run/Dockerfile
+++ b/dockerfiles/python3.6/run/Dockerfile
@@ -1,7 +1,7 @@
-FROM public.ecr.aws/shogo82148/lambda-provided:alami
+FROM ghcr.io/shogo82148/lambda-provided:alami
 
 
-FROM public.ecr.aws/shogo82148/lambda-base:alami
+FROM ghcr.io/shogo82148/lambda-base:alami
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.7/build/Dockerfile
+++ b/dockerfiles/python3.7/build/Dockerfile
@@ -8,7 +8,7 @@ ENV ARCHIVE_URL_AMD64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/x86_6
 RUN curl -sSL "$ARCHIVE_URL_AMD64" | tar -zx -C /
 
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-alami.2024.08.16
+FROM ghcr.io/shogo82148/lambda-base:build-alami.2024.08.16
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.7/run/Dockerfile
+++ b/dockerfiles/python3.7/run/Dockerfile
@@ -11,7 +11,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:alami.2024.08.09
+FROM ghcr.io/shogo82148/lambda-base:alami.2024.08.09
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.8/build/Dockerfile
+++ b/dockerfiles/python3.8/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.8/run/Dockerfile
+++ b/dockerfiles/python3.8/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.9/build/Dockerfile
+++ b/dockerfiles/python3.9/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/python3.9/run/Dockerfile
+++ b/dockerfiles/python3.9/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/ruby2.7/build/Dockerfile
+++ b/dockerfiles/ruby2.7/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.08.16
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.08.16
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/ruby2.7/run/Dockerfile
+++ b/dockerfiles/ruby2.7/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.08.09
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.08.09
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/ruby3.2/build/Dockerfile
+++ b/dockerfiles/ruby3.2/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:build-al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/ruby3.2/run/Dockerfile
+++ b/dockerfiles/ruby3.2/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2.2024.12.13
+FROM ghcr.io/shogo82148/lambda-base:al2.2024.12.13
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/ruby3.3/build/Dockerfile
+++ b/dockerfiles/ruby3.3/build/Dockerfile
@@ -11,7 +11,7 @@ ENV ARCHIVE_URL_ARM64=https://shogo82148-docker-lambda.s3.amazonaws.com/fs/arm64
 RUN case ${TARGETARCH} in "amd64") ARCHIVE_URL=$ARCHIVE_URL_AMD64;; "arm64") ARCHIVE_URL=$ARCHIVE_URL_ARM64;; *) echo "unknown architecture:" ${TARGETARCH}; exit 1;; esac && \
   curl -sSL "$ARCHIVE_URL" | tar -zx -C /
 
-FROM public.ecr.aws/shogo82148/lambda-base:build-al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:build-al2023.2024.11.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/dockerfiles/ruby3.3/run/Dockerfile
+++ b/dockerfiles/ruby3.3/run/Dockerfile
@@ -15,7 +15,7 @@ ENV DOCKER_LAMBDA_INIT_VERSION=1.0.1
 
 RUN curl -sSL "https://github.com/shogo82148/docker-lambda-init/releases/download/v$DOCKER_LAMBDA_INIT_VERSION/docker-lambda-init_${DOCKER_LAMBDA_INIT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xzv
 
-FROM public.ecr.aws/shogo82148/lambda-base:al2023.2024.11.26
+FROM ghcr.io/shogo82148/lambda-base:al2023.2024.11.26
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \

--- a/examples/go1.x/handler.go
+++ b/examples/go1.x/handler.go
@@ -1,8 +1,8 @@
 // Compile with:
-// docker run --rm -v "$PWD":/go/src/handler public.ecr.aws/shogo82148/lambda-go:build-1 sh -c 'go mod download && go build handler.go'
+// docker run --rm -v "$PWD":/go/src/handler ghcr.io/shogo82148/lambda-go:build-1 sh -c 'go mod download && go build handler.go'
 
 // Run with:
-// docker run --rm -v "$PWD":/var/task public.ecr.aws/shogo82148/lambda-go:1 handler '{"Records": []}'
+// docker run --rm -v "$PWD":/var/task ghcr.io/shogo82148/lambda-go:1 handler '{"Records": []}'
 
 package main
 

--- a/examples/nodejs20.x/index.js
+++ b/examples/nodejs20.x/index.js
@@ -1,5 +1,5 @@
 // Just a test lambda, run with:
-// docker run --rm -v "$PWD":/var/task:ro,delegated public.ecr.aws/shogo82148/lambda-nodejs:20 index.handle
+// docker run --rm -v "$PWD":/var/task:ro,delegated ghcr.io/shogo82148/lambda-nodejs:20 index.handle
 
 exports.handler = async (event, context) => {
   console.log(process.execPath);

--- a/examples/nodejs20.x/package.json
+++ b/examples/nodejs20.x/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "docker run --rm -v \"$PWD\":/var/task:ro,delegated public.ecr.aws/shogo82148/lambda-nodejs:20 index.handler '{\"some\": \"event\"}'"
+    "test": "docker run --rm -v \"$PWD\":/var/task:ro,delegated ghcr.io/shogo82148/lambda-nodejs:20 index.handler '{\"some\": \"event\"}'"
   }
 }

--- a/examples/provided/bootstrap
+++ b/examples/provided/bootstrap
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# docker run --rm -v $PWD:/var/task public.ecr.aws/shogo82148/lambda-provided:alami handler '{"some": "event"}'
+# docker run --rm -v $PWD:/var/task ghcr.io/shogo82148/lambda-provided:alami handler '{"some": "event"}'
 
 while true
 do

--- a/scripts/template.yml
+++ b/scripts/template.yml
@@ -19,17 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: fuller-inc/actions-aws-assume-role@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::445285296882:role/lambda-docker-repository-DeploymentRole-1HRJZXKHD4SPU
-          role-session-tagging: true
-
-      # login ECR Public Registry here to avoid the rate limit
-      - name: Login to ECR Public Registry
+      - name: Login to GitHub Packages Container registry
+        env:
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/shogo82148
+          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -54,10 +49,5 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          printenv PASSWORD | docker login --username "$USERNAME" --password-stdin ghcr.io
           dockerfiles/__RUNTIME__/publish-__VARIANT__.sh "ghcr.io/$USERNAME"
           docker logout ghcr.io
-
-      - name: Publish to ECR Public Registry
-        run: |
-          dockerfiles/__RUNTIME__/publish-__VARIANT__.sh "public.ecr.aws/shogo82148"

--- a/scripts/update_dockerfile.pl
+++ b/scripts/update_dockerfile.pl
@@ -96,11 +96,11 @@ sub update_image($runtime, $variant, $image, $tag) {
     say STDERR "updating $runtime-$variant to $version";
 
     my $dockerfile_build = slurp("$basedir/build/Dockerfile");
-    $dockerfile_build =~ s(^FROM public.ecr.aws/shogo82148/lambda-$image:$tag[.][0-9.]+$)(FROM public.ecr.aws/shogo82148/lambda-$image:$tag.$version)gm;
+    $dockerfile_build =~ s(^FROM ghcr.io/shogo82148/lambda-$image:$tag[.][0-9.]+$)(FROM ghcr.io/shogo82148/lambda-$image:$tag.$version)gm;
     spew("$basedir/build/Dockerfile", $dockerfile_build);
 
     my $dockerfile_run = slurp("$basedir/run/Dockerfile");
-    $dockerfile_run =~ s(^FROM public.ecr.aws/shogo82148/lambda-$image:$tag[.][0-9.]+$)(FROM public.ecr.aws/shogo82148/lambda-$image:$tag.$version)gm;
+    $dockerfile_run =~ s(^FROM ghcr.io/shogo82148/lambda-$image:$tag[.][0-9.]+$)(FROM ghcr.io/shogo82148/lambda-$image:$tag.$version)gm;
     spew("$basedir/run/Dockerfile", $dockerfile_run);
 }
 


### PR DESCRIPTION
Maintaining ECR Public incurs costs. To save money, I am switching to GitHub Packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the comprehensive changes across multiple files, here's a concise release note:

- **Migration**
  - Migrated container image repository from Amazon ECR Public to GitHub Container Registry (ghcr.io)
  - Updated all Docker images, workflows, and documentation to use new image locations
  - Deprecated public.ecr.aws/shogo82148 image repository

- **Workflow Changes**
  - Removed AWS ECR-related authentication steps
  - Added GitHub Packages Container registry login steps
  - Updated publishing workflows to use GitHub Container Registry

- **Docker Images**
  - Updated base images across all runtime environments (Python, Node.js, Java, Ruby, etc.)
  - Maintained architecture-specific handling for different platforms
  - Preserved existing runtime configurations and initialization logic

- **Documentation**
  - Updated README with new image references
  - Added deprecation warning for public.ecr.aws images

This migration ensures continued support and accessibility of Lambda runtime images through GitHub's container registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->