### PR TITLE
Remove DotNetCliToolReference for Amazon.Lambda.Tools

### DIFF
--- a/dump/dotnet6/dump-dotnet6.csproj
+++ b/dump/dotnet6/dump-dotnet6.csproj
@@ -12,8 +12,4 @@
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.2.5" />
   </ItemGroup>
 
-  <ItemGroup>
-    <DotNetCliToolReference Include="Amazon.Lambda.Tools" Version="2.2.0" />
-  </ItemGroup>
-
 </Project>

--- a/dump/dotnet8/dump-dotnet8.csproj
+++ b/dump/dotnet8/dump-dotnet8.csproj
@@ -12,8 +12,4 @@
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.2.5" />
   </ItemGroup>
 
-  <ItemGroup>
-    <DotNetCliToolReference Include="Amazon.Lambda.Tools" Version="2.2.0" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Removed a CLI tool dependency from the build configuration across multiple project versions, simplifying the project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->