### PR TITLE
Add Ruby 4.0 runtimes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,12 @@ These follow the Lambda runtime names:
   - `ghcr.io/shogo82148/lambda-python:build-3.10-x86_64`
 
 - [Ruby Runtimes](https://github.com/shogo82148/docker-lambda/pkgs/container/lambda-ruby)
+  - `ghcr.io/shogo82148/lambda-ruby:4.0`
+  - `ghcr.io/shogo82148/lambda-ruby:4.0-arm64`
+  - `ghcr.io/shogo82148/lambda-ruby:4.0-x86_64`
+  - `ghcr.io/shogo82148/lambda-ruby:build-4.0`
+  - `ghcr.io/shogo82148/lambda-ruby:build-4.0-arm64`
+  - `ghcr.io/shogo82148/lambda-ruby:build-4.0-x86_64`
   - `ghcr.io/shogo82148/lambda-ruby:3.4`
   - `ghcr.io/shogo82148/lambda-ruby:3.4-arm64`
   - `ghcr.io/shogo82148/lambda-ruby:3.4-x86_64`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Ruby 4.0 runtime to Docker tags reference with architecture-specific variants for arm64 and x86_64 platforms, including both image and build tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->